### PR TITLE
Update template

### DIFF
--- a/licence.template
+++ b/licence.template
@@ -1,6 +1,6 @@
-Copyright (c) <year> <name>
+The MIT License (MIT)
 
-This software is released under the MIT license:
+Copyright (c) <year> <name>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This ensures that GitHub is able to parse it as the MIT license automatically. The extra line there before was messing up GitHub's internal parser.